### PR TITLE
Fixed layout of some components

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@egym/mwa-logger",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "description": "",
   "author": "EGYM",
   "license": "ISC",

--- a/src/EgymMwaDevtools/CommonLogItem.tsx
+++ b/src/EgymMwaDevtools/CommonLogItem.tsx
@@ -25,6 +25,7 @@ const CommonLogItem: FC<Props> = ({ index , message}) => {
           marginBottom: '20px',
           maxHeight: open ? 'none' : '30px',
           overflow: !open ? 'hidden' : undefined,
+          boxSizing: 'border-box',
         }}
       >
         <LogItemHeader open={open} setOpen={setOpen} text={message.text} />

--- a/src/EgymMwaDevtools/HttpLogItem.tsx
+++ b/src/EgymMwaDevtools/HttpLogItem.tsx
@@ -39,6 +39,7 @@ const HttpLogItem: FC<Props> = ({ index, messages }) => {
           marginBottom: '20px',
           maxHeight: open ? 'none' : '30px',
           overflow: !open ? 'hidden' : undefined,
+          boxSizing: 'border-box',
         }}
       >
         <LogItemHeader text={`${messages[0]?.method?.toUpperCase()} ${messages[0].text}`} color={color} open={open} setOpen={setOpen} />

--- a/src/EgymMwaDevtools/TitleWithSearch.tsx
+++ b/src/EgymMwaDevtools/TitleWithSearch.tsx
@@ -70,7 +70,8 @@ const TitleWithSearch: FC<TitleWithSearchProps> = ({
             fontSize: '14px',
             fontWeight: 500,
             padding: '0 30px 0 5px',
-            outline: 'none'
+            outline: 'none',
+            boxSizing: 'border-box',
           }}/>
           <button type="button" onClick={clearSearch} style={{
             position: 'absolute',
@@ -81,6 +82,7 @@ const TitleWithSearch: FC<TitleWithSearchProps> = ({
             height: '14px',
             background: 'none',
             border: 'none',
+            padding: 0,
           }}>
             <CloseIcon style={{ maxWidth: '100%', maxHeight: '100%' }}/>
           </button>


### PR DESCRIPTION
There are some layout issues in Logger when it's used inside of Wellpass MWAs: close button in Search is not visible, frames for Log Items and Search are misaligned.

Http Log Item:
<img height="206" alt="image" src="https://github.com/user-attachments/assets/a8a730c0-2fd1-4280-8e12-faebf2533206" />

Common Log Item:
<img height="207" alt="image" src="https://github.com/user-attachments/assets/77a0fb9b-8318-4270-8348-f70f0befccd7" />



